### PR TITLE
🐛 Fix: surveyData Save 설문 데이터 저장

### DIFF
--- a/src/api/survey/controller/survey.controller.ts
+++ b/src/api/survey/controller/survey.controller.ts
@@ -1,16 +1,16 @@
-import { Controller, Post, Body, Headers } from '@nestjs/common';
+import { Controller, Post, Body, Req } from '@nestjs/common';
 import { SurveyService } from '../service/survey.service';
 import { SurveyDto } from '../dto/survey.dto';
-import { User } from 'src/entities/user.entity';
+import { Request } from 'express';
 
 @Controller('survey')
 export class SurveyController {
   constructor(private readonly surveyService: SurveyService) {}
 
   @Post()
-  create(@Body() surveyDto: SurveyDto, @Headers('user-id') userId: string) {
-    surveyDto.userId = parseInt(userId);
-
-    return this.surveyService.create(surveyDto);
+  create(@Body() surveyDto: SurveyDto, @Req() request: Request) {
+    const userId = request.cookies['userId'];
+    console.log(userId);
+    return this.surveyService.create(surveyDto, userId);
   }
 }

--- a/src/api/survey/dto/survey.dto.ts
+++ b/src/api/survey/dto/survey.dto.ts
@@ -1,5 +1,5 @@
 import { IsDefined } from 'class-validator';
-import { User } from 'src/entities/user.entity';
+
 export class SurveyDto {
   @IsDefined()
   question1: number;
@@ -9,6 +9,4 @@ export class SurveyDto {
 
   @IsDefined()
   question3: number;
-
-  userId: number;
 }

--- a/src/api/survey/service/survey.service.ts
+++ b/src/api/survey/service/survey.service.ts
@@ -11,12 +11,15 @@ export class SurveyService {
     private readonly surveyRepository: Repository<Survey>,
   ) {}
 
-  async create(surveyDto: SurveyDto) {
-    const newSurvey = this.surveyRepository.create(surveyDto);
+  async create(surveyDto: SurveyDto, userId: number) {
+    const newSurvey = this.surveyRepository.create({
+      ...surveyDto,
+      userId,
+    });
 
     console.log(newSurvey);
 
     await this.surveyRepository.save(newSurvey);
-    return newSurvey;
+    return { message: 'success' };
   }
 }

--- a/src/api/upload/data.ts
+++ b/src/api/upload/data.ts
@@ -52,7 +52,7 @@ export const data = [
       },
     ],
     file_url:
-      'runs/20240131/ae2s8672s2214c2-1224182-4e8w832-b324f2-22s242a2b22d3d0e18da882_2bookshelf1.jpg/ae86714c-1418-4e88-b34f-4ab30e18da88_bookshelf1.jpg',
+      'runs/20240131/ae2s8672s2d214c2-1224182-4e8w832-b324f2-22s242a2b22d3d0e18da882_2bookshelf1.jpg/ae86714c-1418-4e88-b34f-4ab30e18da88_bookshelf1.jpg',
   },
   {
     result: [
@@ -107,6 +107,6 @@ export const data = [
       },
     ],
     file_url:
-      'runs/20240131/a32772284ec-s43222a223b-4ed1-802592w-724220d2222202fd22287d17_bookshelf1.jpg/a37784ec-43ab-4ed1-8059-72400f287d17_bookshelf1.jpg',
+      'runs/20240131/a32772284ec-s43d222a223b-4ed1-802592w-724220d2222202fd22287d17_bookshelf1.jpg/a37784ec-43ab-4ed1-8059-72400f287d17_bookshelf1.jpg',
   },
 ];

--- a/src/entities/bookshelf.entity.ts
+++ b/src/entities/bookshelf.entity.ts
@@ -1,17 +1,20 @@
 import {
   Entity,
-  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { User } from './user.entity';
 
 @Entity()
 export class Bookshelf {
-  @PrimaryColumn({ length: 255, comment: '이미지 경로' })
+  @PrimaryGeneratedColumn({ comment: '책장 이미지PK ' })
+  id: number;
+
+  @Column({ length: 255, comment: '이미지 경로' })
   bookShelfImage: string;
 
   @CreateDateColumn({ comment: '생성 시간' })

--- a/src/entities/survey.entity.ts
+++ b/src/entities/survey.entity.ts
@@ -31,10 +31,10 @@ export class Survey {
   })
   status: string;
 
-  @CreateDateColumn({ comment: 'Record creation time' })
+  @CreateDateColumn({ nullable: true, comment: 'Record creation time' })
   createdAt: Date;
 
-  @UpdateDateColumn({ comment: 'Record last update time' })
+  @UpdateDateColumn({ nullable: true, comment: 'Record last update time' })
   updatedAt: Date;
 
   @ManyToOne(() => User, (user) => user.survey)


### PR DESCRIPTION
### 📟 연결된 이슈
#9 #10 

### 👷 작업한 내용
- [ ] FE에서 전달한 설문조사 내용과 쿠키에 담겨진 userID를 DB에 저장하는 간단한 로직을 수행했다.

### 📸 스크린샷
<img width="1086" alt="image" src="https://github.com/sharebookshelf/Gongcheck-BE/assets/66247589/449315d2-401e-4a5e-894b-468998d68d9d">

<img width="814" alt="image" src="https://github.com/sharebookshelf/Gongcheck-BE/assets/66247589/e71d4184-664e-45e6-953b-9f6561662107">
